### PR TITLE
Improve DX with Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can install this environment by following these steps:
 
 - clone the repo: `git clone git@github.com:mui/tech-challenge-react.git`
 - install the dependencies: `yarn`
-- use a Node.js's version <= 16 and >= 10
+- use a Node.js's version >= 18.0.0 and < 21.0.0
 - start Next.js: `yarn start`
 - open http://0.0.0.0:3002/components/phase1/
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env NODE_ENV=production next build --profile",
     "build:clean": "rimraf .next && yarn build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
-    "dev": "rimraf ./node_modules/.cache/babel-loader && next dev --port 3002",
+    "dev": "rimraf ./node_modules/.cache/babel-loader && NODE_OPTIONS=--openssl-legacy-provider next dev --port 3002",
     "deploy": "git push material-ui-docs next:next",
     "export": "rimraf docs/export && next export --threads=3 -o export && yarn build-sw",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",

--- a/package.json
+++ b/package.json
@@ -212,5 +212,8 @@
     "docs",
     "docs/packages/*",
     "framer"
-  ]
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  }
 }


### PR DESCRIPTION
I'm using Node.js in v18, when I tried to run the challenge locally to leave feedback on https://app.ashbyhq.com/schedules/59e5a029-5c30-471a-89d5-310370df8669/right-side/candidates/3273807c-49dd-49bf-83a2-ff4465739abb/applications/66bee35d-c632-46f7-bd07-247572c8283d/notes. It failed, and it wasn't clear on what went wrong.

This PR makes it work with the latest versions of Node.js and gives a clear error message if the version used is too old.

Fix #17