### PR TITLE
[core] Add 'packageManager' field

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,5 +215,6 @@
   ],
   "engines": {
     "node": ">=18.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.4"
 }


### PR DESCRIPTION
This avoid a git diff for people who have corepack enabled: https://nodejs.org/api/packages.html#packagemanager.

Now, this is getting away, Node.js will remove corepack https://socket.dev/blog/node-js-takes-steps-towards-removing-corepack, so a tiny detail.